### PR TITLE
Updates hooks callback arguments to be supported with Recoil v0.0.10 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "react-dom": "^16.13.1",
     "react-native-web": "^0.12.2",
     "react-scripts": "3.4.1",
-    "recoil": "^0.0.8"
+    "recoil": "^0.0.10"
   },
   "homepage": "https://jimliu.github.io/recoil-paint/",
   "scripts": {

--- a/src/recoil/hooks.js
+++ b/src/recoil/hooks.js
@@ -3,13 +3,13 @@ import { itemWithId } from './selectors';
 import { createNewShape } from './defaults';
 
 export function useUpdateItem() {
-  return useRecoilCallback(({ set }, newValue) => {
+  return useRecoilCallback(({set}) => async (newValue) => {
     set(itemWithId(newValue.id), newValue)
   });
 }
 
 export function useNewItem() {
-  return useRecoilCallback(async ({ getPromise }, shapeParam) => {
+  return useRecoilCallback(({snapshot: {getPromise}}) => async (shapeParam) => {
     let id = createNewShape(shapeParam);
     const item = await getPromise(itemWithId(id));
 
@@ -18,7 +18,7 @@ export function useNewItem() {
 }
 
 export function useLoadItems() {
-  return useRecoilCallback(async ({ getPromise }, itemIds) => {
+  return useRecoilCallback(({snapshot: {getPromise}}) => async (itemIds) => {
     return await Promise.all(
       itemIds.map(id => getPromise(itemWithId(id)))
     );
@@ -26,7 +26,7 @@ export function useLoadItems() {
 }
 
 export function useUpdateItems() {
-  return useRecoilCallback(({ set }, newValue) => {
+  return useRecoilCallback(({set}) => async (newValue) => {
     newValue.forEach(item => {
       set(itemWithId(item.id), item);
     })


### PR DESCRIPTION
Hey Jim,

I am currently working on a debugging tool for the latest version of Recoil (v0.0.10). I am very interested in using this demo based on the level of complexity of it for testing & learning more about how Recoil's state management works.

Thought I'd pass along minor updates to the `useRecoilCallback` hooks that seem to work with the latest version on my end.

Cheers,

Bren